### PR TITLE
README.rst: Fix minor reST problems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Installation
     pip3 install volapi
 
 Examples
--------
+--------
 
 Basic
 ~~~~~
@@ -31,7 +31,7 @@ Basic
             print(msg.nick + ": " + msg.msg)
 
 Listening
-~~~~~~~~~~
+~~~~~~~~~
 
 Some basic trolling can be archieved with just a few lines of code.
 


### PR DESCRIPTION
These may or may not be the sole cause of the description not rendering on PyPI. 

(PyPI is very strict about reST; see https://bitbucket.org/pypa/pypi/pull-request/60/fix-bb-214-make-rst-rendering-not-fail-for)